### PR TITLE
swaplogger.bb: omit x11 inclusion if x11 not in DISTRO_FEATURES

### DIFF
--- a/recipes-qt/swaplogger/swaplogger.bb
+++ b/recipes-qt/swaplogger/swaplogger.bb
@@ -21,7 +21,9 @@ SRCREV = "b06b5476dae2ee56688e3d5f7e0bf4987848d476"
 
 S = "${WORKDIR}/git/"
 
-CFLAGS += "-DLINUX=1 -DEGL_API_FB=1 -shared -fPIC"
+CFLAGS += "-DLINUX=1 -DEGL_API_FB=1 -shared -fPIC \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', '-DMESA_EGL_NO_X11_HEADERS', d)} \
+    "
 
 do_install() {
 	mkdir -p ${D}/${libdir}


### PR DESCRIPTION
Swaplogger depends on EGL/egl.h which includes EGL/eglplatform.h which in turn includes X11/Xlib.h and X11/Xutil.h unless MESA_EGL_NO_X11_HEADERS is set. When building an image without x11 support we obviously don't want this to happen since those headers won't exist in the sysroot.

Sample fail message:

```
| x86_64-bistro-linux-gcc  -m64 -march=corei7 -mtune=corei7 -mfpmath=sse -msse4.2 --sysroot=/home/zarniwoop/XYZ/build/tmp/sysroots/XYZ  -O2 -pipe -g -feliminate-unused-debug-types -DLINUX=1 -DEGL_API_FB=1 -shared -fPIC -DUSE_EGL   -c -o swaplogger_egl.o swaplogger_egl.c
| In file included from /home/zarniwoop/XYZ/build/tmp/sysroots/XYZ/usr/include/EGL/egl.h:36:0,
|                  from swaplogger_egl.c:26:
| /home/zarniwoop/XYZ/build/tmp/sysroots/XYZ/usr/include/EGL/eglplatform.h:118:22: fatal error: X11/Xlib.h: No such file or directory
|  #include <X11/Xlib.h>
|                       ^
| compilation terminated.
| <builtin>: recipe for target 'swaplogger_egl.o' failed
| make: *** [swaplogger_egl.o] Error 1
| ERROR: oe_runmake failed
```