### PR TITLE
pulseaudio: remove bluetooth and bluez5 from package config

### DIFF
--- a/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -9,8 +9,6 @@ RDEPENDS_pulseaudio-server += " \
     pulseaudio-misc \
 "
 
-PACKAGECONFIG += "bluez5 bluetooth"
-
 SRC_URI += "file://pulseaudio-mutex-assert-fix.patch"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
Bluetooth support should be added in the project specific layer if
there is a need for it. Compilation errors might occur otherwise.