### PR TITLE
core-image-bistro-sdk.bb: Remove dependency on ipforward

### DIFF
--- a/recipes-core/images/core-image-bistro-sdk-1.1.bb
+++ b/recipes-core/images/core-image-bistro-sdk-1.1.bb
@@ -8,7 +8,7 @@ inherit core-image
 inherit populate_sdk_qt5_qtcreator
 
 # Network management
-IMAGE_INSTALL += "connman ipforward"
+IMAGE_INSTALL += "connman"
 
 # helpers (dev)
 IMAGE_FEATURES += "package-management"


### PR DESCRIPTION
Removes the last dependency on ipforward. 