### PR TITLE
systemd bbappend: Split into version specific and generic part

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,6 @@
+#
+#   Copyright (C) 2015 Pelagicore AB
+#   All rights reserved.
+#
+
+PACKAGECONFIG += " networkd resolved "

--- a/recipes-core/systemd/systemd_225.bbappend
+++ b/recipes-core/systemd/systemd_225.bbappend
@@ -5,5 +5,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += "file://systemd-udev-use-external-blkid.patch"
 RDEPENDS_udev += "util-linux-blkid"
-
-PACKAGECONFIG += " networkd resolved "


### PR DESCRIPTION
networkd and resolved should be enabled regardless of systemd version,
so put this in a bbappend matching all system versions