### PR TITLE
Add native dependencies for CommonAPI code generator.

### DIFF
--- a/layers/ivi/recipes-core/common-api/common-api-c++-dbus-codegen.bb
+++ b/layers/ivi/recipes-core/common-api/common-api-c++-dbus-codegen.bb
@@ -7,7 +7,7 @@ LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
 PR = "r0"
 
-DEPENDS = "common-api-cmdline-codegen common-api-c++-codegen"
+DEPENDS = "common-api-c++-codegen common-api-dbus-integration"
 
 inherit cmake maven-properties
 

--- a/layers/ivi/recipes-core/common-api/common-api-c++-dbus_%.bbappend
+++ b/layers/ivi/recipes-core/common-api/common-api-c++-dbus_%.bbappend
@@ -1,0 +1,10 @@
+#
+#   Copyright (C) 2016 Pelagicore AB
+#
+
+# add native dependencies for CommonAPI code generator
+DEPENDS += "\
+    common-api-cmdline \
+    common-api-cmdline-codegen-native \
+    common-api-c++-dbus-codegen-native \
+"

--- a/layers/ivi/recipes-core/common-api/common-api-cmdline.bb
+++ b/layers/ivi/recipes-core/common-api/common-api-cmdline.bb
@@ -3,8 +3,6 @@
 #
 require ${PN}-common.inc
 
-DEPENDS += "common-api-dbus-integration"
-
 inherit cmake
 
 S = "${WORKDIR}/git/cmake"

--- a/layers/ivi/recipes-core/common-api/common-api-dbus-integration.bb
+++ b/layers/ivi/recipes-core/common-api/common-api-dbus-integration.bb
@@ -17,3 +17,4 @@ FILES_${PN}-dev += "${libdir}/cmake/*"
 
 ALLOW_EMPTY_${PN} = "1"
 
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Applications should only need common-api-c++-dbus as their dependency.