### PR TITLE
qtwayland-native_git.bbappend: Remove QtWayland bbappend

### DIFF
--- a/layers/qt5-layer/recipes-qt/qt5/qtwayland-native_git.bbappend
+++ b/layers/qt5-layer/recipes-qt/qt5/qtwayland-native_git.bbappend
@@ -1,5 +1,0 @@
-#
-#   Copyright (C) 2015 Pelagicore AB
-#   All rights reserved.
-#
-QT_MODULE_BRANCH="dev"


### PR DESCRIPTION
* The component branch and source revision should be stated
in the original meta-qt5 recipe