### PR TITLE
adds recipes for some OSS packages

### DIFF
--- a/recipes-support/dbus-proxy/dbus-proxy.bb
+++ b/recipes-support/dbus-proxy/dbus-proxy.bb
@@ -1,0 +1,25 @@
+#
+#   Copyright (C) 2015 Pelagicore AB
+#   All rights reserved.
+#
+DESCRIPTION = "dbus-proxy"
+HOMEPAGE = "http://www.pelagicore.com"
+LICENSE = "LGPLv2.1"
+PR = "r0"
+
+inherit cmake
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=4fbd65380cdd255951079008b364516c"
+
+DEPENDS = "dbus dbus-glib glib-2.0 jansson"
+
+SRC_URI = "git://github.com/Pelagicore/dbus-proxy.git;protocol=https;branch=master"
+SRCREV = "6f8dfcefb83cee5513f4ffcc46f12dcf701598f5"
+PV = "0.1+git${SRCREV}"
+
+S = "${WORKDIR}/git/"
+
+FILES_${PN} += " \
+	${bindir}/ \
+	"
+

--- a/recipes-support/ivi-logging/ivi-logging.bb
+++ b/recipes-support/ivi-logging/ivi-logging.bb
@@ -1,0 +1,9 @@
+#
+#   Copyright (C) 2015 Pelagicore AB
+#   All rights reserved.
+#
+require ${PN}.inc
+
+SRC_URI = "${GIT_REPO};branch=master"
+SRCREV = "4917817a7510cfb984fbabe6882c17d4e0e902e6"
+PV = "0.1+git${SRCREV}"

--- a/recipes-support/ivi-logging/ivi-logging.inc
+++ b/recipes-support/ivi-logging/ivi-logging.inc
@@ -1,0 +1,23 @@
+DESCRIPTION = "ivi-logging"
+HOMEPAGE = "http://www.pelagicore.com"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=815ca599c9df247a0c7f619bab123dad"
+PR = "r0"
+
+DEPENDS = "glib-2.0"
+
+inherit cmake
+
+# Make DLT support optional
+# To enable, create a .bbappend with PACKAGECONFIG_append = "dlt"
+# in your project layer
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[dlt] = "-DENABLE_DLT_BACKEND=ON,,dlt-daemon,"
+
+GIT_REPO = "git://github.com/Pelagicore/ivi-logging.git;protocol=https"
+S = "${WORKDIR}/git"
+
+FILES_${PN}-dev += " \
+       ${libdir}/cmake/ \
+       ${docdir}/ \
+       "


### PR DESCRIPTION
- IVI-logging has been OSS for a long time, but an open recipe for it has been missing.
- The pelagicore fork of dbus-proxy was released to GitHub recently, this adds a recipe for that.