### PR TITLE
conf: Generate Qemu binary for AARCH64

### DIFF
--- a/conf/distro/bistro.inc
+++ b/conf/distro/bistro.inc
@@ -54,7 +54,7 @@ DISTRO_EXTRA_RDEPENDS_append_qemux86-64 = " ${POKYQEMUDEPS}"
 
 TCLIBCAPPEND = ""
 
-QEMU_TARGETS ?= "arm i386 mips mipsel ppc x86_64"
+QEMU_TARGETS ?= "arm i386 mips mipsel ppc x86_64 aarch64"
 # Other QEMU_TARGETS "mips64 mips64el sh4"
 
 PREMIRRORS ?= "\


### PR DESCRIPTION
Not sure why it wasn't done so already (I'm new to all this) but we need
qemu-aarch64 binary for building gobject-introspection, which is required
by many GNOME packages. I noticed this when building Geoclue2.