### PR TITLE
systemd_229: make sure users are created for systemd-networkd and sys…

### DIFF
--- a/recipes-core/systemd/systemd_229.bbappend
+++ b/recipes-core/systemd/systemd_229.bbappend
@@ -1,0 +1,2 @@
+USERADD_PARAM_${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'networkd', '--system -d / -M --shell /bin/nologin systemd-network;', '', d)}"
+USERADD_PARAM_${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'resolved', '--system -d / -M --shell /bin/nologin systemd-resolve;', '', d)}"


### PR DESCRIPTION
…temd-resolved

These two services needs their respective users to be created in order to work. This is fixed in poky master for systemd 230 but needs manual fixing for krogoth system version (229).