### PR TITLE
Remove ${PN} from SRC_URI

### DIFF
--- a/layers/multimedia-layer/recipes-multimedia/dleyna/dleyna-git.inc
+++ b/layers/multimedia-layer/recipes-multimedia/dleyna/dleyna-git.inc
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/git/COPYING;md5=4fbd65380cdd255951079008b3
 
 DEPENDS += "gupnp gupnp-dlna gupnp-av"
 
-SRC_URI = "git://github.com/01org/${PN}.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/01org/${BPN}.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git/"
 


### PR DESCRIPTION
In newer yocto versions it seems that the ${PN} variable is not
expanded anymore if it is in the SRC_URI, we got the error:

-------------------
ERROR: ExpansionError during parsing
meta-bistro/layers/multimedia-layer/recipes-multimedia/dleyna/dleyna-core_git.bb:
Failure expanding variable SRCPV, expression was ${@bb.fetch2.get_srcrev(d)}
which triggered exception FetchError: Fetcher failure: The
SRCREV_FORMAT variable must be set when multiple SCMs are used.
-------------------

Replacing the ${PN} with ${BPN} makes it possible to use this layer again.