### PR TITLE
Removed append since this is the original recipe.

### DIFF
--- a/recipes-core/dbus-session/dbus-session.bb
+++ b/recipes-core/dbus-session/dbus-session.bb
@@ -17,9 +17,9 @@ DEPENDS = "systemd dbus"
 
 inherit systemd
 
-do_install_append() {
+do_install() {
     install -Dm0644 ${S}/dbus-session@.service \
-        ${D}/${base_libdir}/systemd/system/dbus-session@.service
+    ${D}/${base_libdir}/systemd/system/dbus-session@.service
 }
 
 SYSTEMD_SERVICE_${PN}="dbus-session@.service"


### PR DESCRIPTION
A master recipe shouldn't have _append since it's the
one doing the install. Having _append there also would prevent
a downstream bbappend.