### PR TITLE
core-image-bistro: Add bluetooth default packages

### DIFF
--- a/recipes-core/images/core-image-bistro.bb
+++ b/recipes-core/images/core-image-bistro.bb
@@ -14,6 +14,12 @@ IMAGE_FEATURES += "package-management"
 # systemd units
 IMAGE_INSTALL += "systemd-additional-units"
 
+# Include bluetooth if the machine supports it (MACHINE_FEATURES), and it has
+# been selected in DISTRO_FEATURES.
+IMAGE_INSTALL += "\
+    ${@base_contains("COMBINED_FEATURES", "bluetooth", "packagegroup-tools-bluetooth", "", d)} \
+"
+
 TOOLCHAIN_HOST_TASK += "nativesdk-cmake"
 
 # Add "/usr/lib/cmake" to the PATH variable so that CMake can find the *Config.cmake" when FIND_PACKAGE() is called from a CMake makefile


### PR DESCRIPTION
This adds the packagegroup "packagegroup-tools-bluetooth" to all Bistro
images which satisfy the following:

- Machine type supports the "bluetooth" MACHINE_FEATURE
- "bluetooth" has not been explicitly disabled by removing it from the
  default DISTRO_FEATURES set by Bistro.

This means that BT-capable machines will now gain the following
packages:

- bluez5-noinst-tools
- bluez5-obex
- bluez5-testtools
- libasound-module-bluez

If the pulseaudio distro feature has not been removed from the default
DISTRO_FEATURES, the following packages are also installed:

- pulseaudio-module-bluetooth-discover
- pulseaudio-module-bluetooth-policy
- pulseaudio-module-bluez5-discover
- pulseaudio-module-bluez5-device
- pulseaudio-module-switch-on-connect
- pulseaudio-module-loopback

All in all, these packages enable A2DP and AVRCP on machines with
bluetooth capabilities.

PulseAudio also gains the capability to switch to a new bluetooth A2DP
source upon discovery, using the switch-on-connect + loopback modules.
This behavior needs to be explicitly enabled in the pulseaudio config.

Signed-off-by: Jonatan Pålsson <jonatan.palsson@pelagicore.com>