### PR TITLE
gst-instruments: Add recipe

### DIFF
--- a/recipes-multimedia/gst-instruments/gst-instruments_git.bb
+++ b/recipes-multimedia/gst-instruments/gst-instruments_git.bb
@@ -1,0 +1,14 @@
+SUMMARY = "Profiling utilities for GStreamer 1.0 pipelines"
+HOMEPAGE = "https://github.com/kirushyk/gst-instruments"
+DEPENDS = "gstreamer1.0"
+
+LICENSE = "LGPL-3.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e6a600fd5e1d9cbde2d983680233ad02"
+
+inherit autotools pkgconfig
+
+PV = "0.2.1+git${SRCPV}"
+SRC_URI = "git://github.com/kirushyk/gst-instruments.git;protocol=https"
+SRCREV = "55c305035242292b79607a4bc113440f4fb72efb"
+
+S = "${WORKDIR}/git"


### PR DESCRIPTION
Add recipe for gst-instruments. This is a set of utilities used to
profile CPU usage of GStreamer pipeline elements. The gst-top utility is
used to launch a gstreamer pipeline and record its profile, and the
gst-report utility is used to analyze reports gathered by gst-top.

Signed-off-by: Jonatan Pålsson <jonatan.palsson@pelagicore.com>