### PR TITLE
common-api: add comments about sstate-cache

### DIFF
--- a/layers/ivi/recipes-core/common-api/common-api-c++-dbus_%.bbappend
+++ b/layers/ivi/recipes-core/common-api/common-api-c++-dbus_%.bbappend
@@ -3,6 +3,8 @@
 #
 
 # add native dependencies for CommonAPI code generator
+# NOTE: problems were (rarely) observed in triggering these dependencies
+#       while rebuilding from sstate-cache on Yocto 2.1
 DEPENDS += "\
     common-api-cmdline \
     common-api-cmdline-codegen-native \


### PR DESCRIPTION
While rebuilding from sstate-cache on Yocto 2.1. it was, rarely but still, observed that some components using the CommonAPI code generator were missing parts of the tooling supposed to be pulled in by this list of dependencies.