### PR TITLE
qtbase: remove explicit openssl PACKAGECONFIG

### DIFF
--- a/layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -15,7 +15,6 @@ PACKAGECONFIG += " \
     fontconfig \
     icu \
     kms \
-    openssl \
     sql-sqlite \
 "
 


### PR DESCRIPTION
The qtbase OpenSSL PACKAGECONFIG argument is added by default in meta-qt5.