### PR TITLE
ivi-logging: update SRCREV to latest

### DIFF
--- a/recipes-support/ivi-logging/ivi-logging.bb
+++ b/recipes-support/ivi-logging/ivi-logging.bb
@@ -5,5 +5,5 @@
 require ${PN}.inc
 
 SRC_URI = "${GIT_REPO};branch=master"
-SRCREV = "2367a29a413fb18dc8af4d9fe41620e1b5faaf15"
+SRCREV = "7ec74df57744189bdccb77a184beceefaf446ba3"
 PV = "0.1+git${SRCREV}"


### PR DESCRIPTION
Update SRCREV in order to get fix for ivi-logging on 32-bit systems.