### PR TITLE
lms: Fix LightMediaScanner recipe

### DIFF
--- a/recipes-support/lms/lms_0.4.5.bb
+++ b/recipes-support/lms/lms_0.4.5.bb
@@ -9,6 +9,7 @@ HOMEPAGE = "https://github.com/profusion/lightmediascanner"
 inherit autotools pkgconfig gettext
 
 DEPENDS = "sqlite3"
+RDEPENDS_${PN} = "libflac mp4v2 libvorbis libogg"
 
 PR = "r0"
 

--- a/recipes-support/lms/lms_0.4.5.bb
+++ b/recipes-support/lms/lms_0.4.5.bb
@@ -15,7 +15,7 @@ PR = "r0"
 EXTRA_OECONF += "--program-prefix=lms-"
 
 SRCREV = "454be49d1fd22c82d78bddd91f61e478c50b8aa0"
-SRC_URI = "git://git.profusion.mobi/lightmediascanner.git \
+SRC_URI = "git://github.com/profusion/lightmediascanner.git \
 	   file://0001-Install-binaries-in-bin-directory.patch"
 
 S = "${WORKDIR}/git"

--- a/recipes-support/lms/lms_0.4.5.bb
+++ b/recipes-support/lms/lms_0.4.5.bb
@@ -21,3 +21,4 @@ SRC_URI = "git://github.com/profusion/lightmediascanner.git \
 S = "${WORKDIR}/git"
 
 FILES_${PN} += "${libdir}/lightmediascanner/plugins/*.so"
+FILES_${PN}-dev += "${libdir}/lightmediascanner/plugins/*.la"


### PR DESCRIPTION
Fix repository link, package missing .la files and add missing RDEPENDS.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>