### PR TITLE
Change fetcher protocol from git to https

### DIFF
--- a/layers/qt5-layer/recipes-qt/swaplogger/swaplogger.bb
+++ b/layers/qt5-layer/recipes-qt/swaplogger/swaplogger.bb
@@ -14,7 +14,7 @@ LICENSE = "Nokia"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d25f5ab7fee8539cd6db2dcf074cece6"
 
 SRC_URI = " \
-       git://github.com/mer-tools/swaplogger.git;branch=master \
+       git://github.com/mer-tools/swaplogger.git;protocol=https;branch=master \
        file://fix_makefile.patch \
        "
 

--- a/recipes-core/systemd/systemd-additional-units.bb
+++ b/recipes-core/systemd/systemd-additional-units.bb
@@ -12,7 +12,7 @@ PR = "r1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 SRC_URI = " \
-	git://github.com/sofar/user-session-units.git;protocol=git \
+	git://github.com/sofar/user-session-units.git;protocol=https \
 	file://dbus-socket-run-dir.patch \
 	file://light.target \
 	"

--- a/recipes-support/lms/lms_0.4.5.bb
+++ b/recipes-support/lms/lms_0.4.5.bb
@@ -18,7 +18,7 @@ PR = "r0"
 EXTRA_OECONF += "--program-prefix=lms-"
 
 SRCREV = "454be49d1fd22c82d78bddd91f61e478c50b8aa0"
-SRC_URI = "git://github.com/profusion/lightmediascanner.git \
+SRC_URI = "git://github.com/profusion/lightmediascanner.git;protocol=https \
 	   file://0001-Install-binaries-in-bin-directory.patch"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The default fetcher protocol should be https. Often inside of corporate
networks the git port 9418 is blocked. To make it easier for
meta-bistro to get adopted by others we should not use the git
protocol.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>