### PR TITLE
cairo: Remove all libtrace files

### DIFF
--- a/recipes-temporary-patches/cairo/cairo_%.bbappend
+++ b/recipes-temporary-patches/cairo/cairo_%.bbappend
@@ -3,6 +3,6 @@
 # This is fixed in meta-ivi but not in 13.0 branch (pyro)
 
 do_install_append() {
-   rm ${D}${libdir}/cairo/libcairo-trace.la
+   rm ${D}${libdir}/cairo/libcairo-trace.*
    rmdir ${D}${libdir}/cairo/
 }


### PR DESCRIPTION
In some cases there are more files created than the .la file which also
needs to be removed.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>