### PR TITLE
systemd-genivi-targets: Fix focussed.target

### DIFF
--- a/recipes-core/systemd/systemd-genivi-targets/focussed.target
+++ b/recipes-core/systemd/systemd-genivi-targets/focussed.target
@@ -1,5 +1,5 @@
 [Unit]
 Description=Focussed Target
-After=node-state-controller.service
+After=node-startup-controller.service
 Requires=basic.target
 AllowIsolate=yes


### PR DESCRIPTION
Currently focussed.target starts after node-state-controller, but
the service is actually called node-startup-controller.

Signed-off-by: Erik Botö <erik.boto@pelagicore.com>