### PR TITLE
packagegroups: Split into debug utils and utils

### DIFF
--- a/recipes-core/packagegroups/packagegroup-bistro-utils.bb
+++ b/recipes-core/packagegroups/packagegroup-bistro-utils.bb
@@ -11,28 +11,31 @@ PR = "r1"
 inherit packagegroup
 
 PROVIDES = "${PACKAGES}"
-PACKAGES = "packagegroup-bistro-utils"
+PACKAGES = "packagegroup-bistro-utils \
+            packagegroup-bistro-debug-utils"
 
 RDEPENDS_packagegroup-bistro-utils = " \
     alsa-utils-amixer                  \
     alsa-utils-alsamixer               \
-    connman                            \
-    connman-client                     \
     ethtool                            \
     fbset                              \
     gawk                               \
-    gdbserver                          \
     git                                \
-    ldd                                \
     lsof                               \
-    ltrace                             \
     net-tools                          \
     openssh-sftp-server                \
     perf                               \
     rsync                              \
-    swaplogger                         \
-    systemd-additional-units           \
-    systemd-analyze                    \
-    valgrind                           \
     vim                                \
+"
+
+RDEPENDS_packagegroup-bistro-debug-utils = " \
+    gdbserver                                \
+    ldd                                      \
+    ltrace                                   \
+    swaplogger                               \
+    systemd-additional-units                 \
+    systemd-analyze                          \
+    strace                                   \
+    valgrind                                 \
 "


### PR DESCRIPTION
Split packagegroup utils into two groups:
    One group for general utils
    One group for debug utils

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>