### PR TITLE
systemd: remove obsolete bbappend

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,7 +1,0 @@
-#
-#   Copyright (C) 2015 Pelagicore AB
-#
-#   SPDX-License-Identifier: MIT
-#
-
-PACKAGECONFIG += " networkd resolved "


### PR DESCRIPTION
The default value of PACKAGECONFIG in upstream systemd recipe already
contain networkd and resolved.

This bbappend use += to add those values, and the original recipe uses
a weak default value (??=), which means that those weak defaults will
not be used. Instead PACKAGECONFIG will only contain networkd and
resolved which is not the intention.

Signed-off-by: Erik Botö <erik.boto@pelagicore.com>