### PR TITLE
gdbus-codegen-glibmm: Split recipe into .inc and .bb file

### DIFF
--- a/recipes-devtools/gdbus-codegen-glibmm/gdbus-codegen-glibmm.inc
+++ b/recipes-devtools/gdbus-codegen-glibmm/gdbus-codegen-glibmm.inc
@@ -1,0 +1,25 @@
+SUMMARY = "This is a code generator for generating D-Bus stubs and proxies from XML introspection files"
+DESCRIPTION = "This is a code generator for generating D-Bus stubs and proxies \
+from XML introspection files. The generated stubs and proxies are implemented \
+using glibmm and giomm. This generator is based on the gdbus-codegen code \
+generator which ships with glib."
+HOMEPAGE = "https://github.com/Pelagicore/gdbus-codegen-glibmm"
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=4fbd65380cdd255951079008b364516c"
+
+DEPENDS = "python3-jinja2-native python3-markupsafe-native"
+
+S = "${WORKDIR}/git/"
+
+inherit setuptools3
+
+do_install_append_class-native() {
+    sed -i '1 c\#!/usr/bin/env nativepython3' ${D}${bindir}/${BPN}2
+}
+
+# Dependencies for building this software.
+RDEPENDS_${PN} = "python3 python3-setuptools python3-jinja2"
+
+BBCLASSEXTEND = "native nativesdk"
+
+PACKAGE =+ "${PN}"

--- a/recipes-devtools/gdbus-codegen-glibmm/gdbus-codegen-glibmm_2.99.0.bb
+++ b/recipes-devtools/gdbus-codegen-glibmm/gdbus-codegen-glibmm_2.99.0.bb
@@ -1,27 +1,5 @@
-SUMMARY = "This is a code generator for generating D-Bus stubs and proxies from XML introspection files"
-DESCRIPTION = "This is a code generator for generating D-Bus stubs and proxies \
-from XML introspection files. The generated stubs and proxies are implemented \
-using glibmm and giomm. This generator is based on the gdbus-codegen code \
-generator which ships with glib."
-HOMEPAGE = "https://github.com/Pelagicore/gdbus-codegen-glibmm"
-LICENSE = "LGPLv2.1"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=4fbd65380cdd255951079008b364516c"
-DEPENDS = "python3-jinja2-native python3-markupsafe-native"
+
+require gdbus-codegen-glibmm.inc
+
+SRC_URI = "https://github.com/Pelagicore/gdbus-codegen-glibmm.git"
 SRCREV = "c4ed6e0f6cdc21d41503e8312108e21715dceb2d"
-
-SRC_URI = "git://github.com/pelagicore/gdbus-codegen-glibmm;branch=master"
-
-S = "${WORKDIR}/git/"
-
-inherit setuptools3
-
-do_install_append_class-native() {
-    sed -i '1 c\#!/usr/bin/env nativepython3' ${D}${bindir}/${BPN}2
-}
-
-# Dependencies for building this software.
-RDEPENDS_${PN} = "python3 python3-setuptools python3-jinja2"
-
-BBCLASSEXTEND = "native nativesdk"
-
-PACKAGE =+ "${PN}"


### PR DESCRIPTION
Change to use both a .inc and a .bb file. This enables projects to use
more than one version of the tool.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>