### PR TITLE
Snowboy: Add qemu as machine

### DIFF
--- a/recipes-alexa/snowboy/snowboy_1.3.0.bb
+++ b/recipes-alexa/snowboy/snowboy_1.3.0.bb
@@ -14,7 +14,7 @@ SRC_URI = "https://github.com/Kitt-AI/snowboy/archive/v${PV}.tar.gz"
 SRC_URI[md5sum] = "e16e117914f76f4a35facb16b0fcd61b"
 SRC_URI[sha256sum] = "93658cc5d4d83dd7a6e954d0dc1e18d1c70b1dd8623181850c4804d3aca19e96"
 
-COMPATIBLE_MACHINE = "(machine-native|android|intel-corei7-64|raspberrypi3)"
+COMPATIBLE_MACHINE = "(machine-native|android|intel-corei7-64|raspberrypi3|qemux86-64)"
 
 INSANE_SKIP_${PN} += "already-stripped"
 
@@ -25,6 +25,8 @@ def get_snowboy_arch(d):
     elif machine == "androidarm64":
         return "android/armv8-aarch64"
     elif machine == "intel-corei7-64":
+        return "ubuntu64"
+    elif machine == "qemux86-64":
         return "ubuntu64"
     elif machine == "raspberrypi3":
         return "rpi"


### PR DESCRIPTION
Smoke tests were failing to start bitbaking due to non-existing
qemux86-64 machine. This fixes the issue and allows the minimal image to
be bitbaked.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>